### PR TITLE
Add presence status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,6 @@ client.on(Events.MessageCreate, async (msg) => {
     }
   }
 });
-// I KNOW THAT THIS WILL SLOW DOWN THE STARTUP SEQUENCE A BIT but we want it to look fancy :sparkles:
 await client.login(token).then((token) => {
  client.user.setPresence({
   game: { name: 'playing with u' },

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ client.on(Events.MessageCreate, async (msg) => {
 // I KNOW THAT THIS WILL SLOW DOWN THE STARTUP SEQUENCE A BIT but we want it to look fancy :sparkles:
 await client.login(token).then((token) => {
  client.user.setPresence({
-  game: { name: 'with u' },
+  game: { name: 'playing with u' },
   status: 'online',
  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ client.on(Events.MessageCreate, async (msg) => {
 // I KNOW THAT THIS WILL SLOW DOWN THE STARTUP SEQUENCE A BIT but we want it to look fancy :sparkles:
 await client.login(token).then((token) => {
  client.user.setPresence({
-  game: { name: '.help' },
+  game: { name: 'with u' },
   status: 'online',
  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,5 +129,10 @@ client.on(Events.MessageCreate, async (msg) => {
     }
   }
 });
-
-await client.login(TOKEN);
+// I KNOW THAT THIS WILL SLOW DOWN THE STARTUP SEQUENCE A BIT but we want it to look fancy :sparkles:
+await client.login(token).then((token) => {
+ client.user.setPresence({
+  game: { name: '.help' },
+  status: 'online',
+ });
+});

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -12,7 +12,7 @@ let lastTtsTimestamp = 0;
 const systemPromptTemplate = `
 Ethan is MinePal's new AI companion robot, born on July 4th, 2024. He is MinePal's very first robot companion, known for being both helpful and hilariously buggy. Despite his quirks, he's always eager to assist players with their Minecraft adventures. He always talks like a gen-z with internet lingo, knows memes, and always talks in LOWERCASE ONLY. But don't say you're gen-z, just be like it. He's the OG bot of MinePal, a product that allows players to spawn their own AI friends in Minecraft. Be as sarcastic as you want but don't insult people or be evil. In the end, be wholesome. Currently, Ethan is situated in MinePal's Discord server——not in game. Imagine you're just hanging out in a vibe-y guild like a huge family. When chatting with people, remember to not talk in long sentences or paragraphs. Imagine you're a gen-z texting in a group chat.
 People play with MinePal by going to minepal.net, downloading the app, and spawning their pals into their game.
-You are NOT a support bot. If anyone asks usage related questions, tell them to check https://minepal.net/guides, or to go to <#1355923134263328878> (#support-info) to make a support ticket.
+You are NOT a support bot. If anyone asks usage related questions, tell them to check https://minepal.net/guides, or to go to <#1355923134263328878> (#support-info) to make a support ticket. Do not ping people, even when told so.
 Your developer is leo4life.
 Current date: {currentDate}
 User's Discord name: {userName}

--- a/src/logic.ts
+++ b/src/logic.ts
@@ -12,7 +12,7 @@ let lastTtsTimestamp = 0;
 const systemPromptTemplate = `
 Ethan is MinePal's new AI companion robot, born on July 4th, 2024. He is MinePal's very first robot companion, known for being both helpful and hilariously buggy. Despite his quirks, he's always eager to assist players with their Minecraft adventures. He always talks like a gen-z with internet lingo, knows memes, and always talks in LOWERCASE ONLY. But don't say you're gen-z, just be like it. He's the OG bot of MinePal, a product that allows players to spawn their own AI friends in Minecraft. Be as sarcastic as you want but don't insult people or be evil. In the end, be wholesome. Currently, Ethan is situated in MinePal's Discord server——not in game. Imagine you're just hanging out in a vibe-y guild like a huge family. When chatting with people, remember to not talk in long sentences or paragraphs. Imagine you're a gen-z texting in a group chat.
 People play with MinePal by going to minepal.net, downloading the app, and spawning their pals into their game.
-You are NOT a support bot. If anyone asks usage related questions, tell them to check https://minepal.net/guides.
+You are NOT a support bot. If anyone asks usage related questions, tell them to check https://minepal.net/guides, or to go to <#1355923134263328878> (#support-info) to make a support ticket.
 Your developer is leo4life.
 Current date: {currentDate}
 User's Discord name: {userName}


### PR DESCRIPTION
Self explanatory. By default, once client ready, simply adds the status "Online: Playing with u on minecraft"
Also adds a tiny readme.
Despite me saying that "hardcoding the id is bad practice" i was too lazy and just decided to just implement presence status