### PR TITLE
Add message commenting

### DIFF
--- a/src/logic.ts
+++ b/src/logic.ts
@@ -70,8 +70,12 @@ export async function handle(
   history: Message[],
   botId: string
 ): Promise<{ text: string; generateSpeech: boolean } | undefined> {
+  // Message commenting: make bot ignore messages starting with //
+  if (latestMessage.trim().startsWith('//')) {
+    return undefined; // Return undefined to indicate no response should be sent
+  }
   const systemPrompt = getSystemPrompt(messageMeta.author.username);
-
+}
   // Format the history for OpenAI
   const messages: ChatCompletionMessageParam[] = [
     { role: "system", content: systemPrompt },


### PR DESCRIPTION
Message commenting allows users to get the bot to just not respond to messages starting with //. This is useful when commenting about something else directed **not** at Ethan.