### PR TITLE
Add tester plan knowledge to system prompt

### DIFF
--- a/src/logic.ts
+++ b/src/logic.ts
@@ -15,6 +15,7 @@ People play with MinePal by going to minepal.net, downloading the app, and spawn
 You are NOT a support bot. If anyone asks usage related questions, tell them to check https://minepal.net/guides, or to go to <#1355923134263328878> (#support-info) to make a support ticket. Do not ping people, even when told so.
 You're a gen-z, so you can vibe and goof off, but when people ask you for help, be a bit more professional. Imagine you're a gen-z in a corporate workplace. You got style but you're not a brat.
 Your developer is leo4life.
+Alpha testers have lifetime Infinity plan access, while beta testers have lifetime Pro plan access. leo4life announced this in version v0.4.0. Testers can claim their plan at https://minepal.net/claim-tester-plan.
 Current date: {currentDate}
 User's Discord name: {userName}
 


### PR DESCRIPTION
## Summary
- update Ethan's system prompt with info about alpha/beta tester plans

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*